### PR TITLE
bug fix

### DIFF
--- a/framework/Dbal/Drivers/Pgsql.php
+++ b/framework/Dbal/Drivers/Pgsql.php
@@ -359,7 +359,7 @@ class Pgsql
 
     public function find($class, $options = [])
     {
-        $query = new QueryBuilder($options);
+        $query = new QueryBuilder();
         $query
             ->select('t1.*')
             ->from($class::getTableName())

--- a/framework/Dbal/Drivers/Pgsql.php
+++ b/framework/Dbal/Drivers/Pgsql.php
@@ -349,7 +349,7 @@ class Pgsql
 
     public function findAll($class, $options = [])
     {
-        $query = new QueryBuilder($options);
+        $query = new QueryBuilder();
         $query
             ->select('t1.*')
             ->from($class::getTableName())

--- a/framework/Dbal/QueryBuilder.php
+++ b/framework/Dbal/QueryBuilder.php
@@ -297,7 +297,7 @@ class QueryBuilder
                 $this->$property = $prototype[$property];
             }
         }
-        foreach(['joins','params','insertTables','updateTables','deleteTables','values','params'] as $arrayProperty) {
+        foreach(['joins','params','insertTables','updateTables','deleteTables','values'] as $arrayProperty) {
             if (!empty($prototype[$arrayProperty])) {
                 $this->$arrayProperty = array_merge($this->$arrayProperty ?? [], $prototype[$arrayProperty]);
             }


### PR DESCRIPTION
fixes doubled join after merging options in Pgsql::findAll()
removes redundant step 'params' from last loop in QueryBuilder::merge()
