### PR TITLE
Багфикс prepareNames для моделей с указанием схемы

### DIFF
--- a/framework/Dbal/Query.php
+++ b/framework/Dbal/Query.php
@@ -98,15 +98,7 @@ class Query
     protected function trimName($s)
     {
         $trimmed = trim($s, " \"'`\t\n\r\0\x0B");
-        if (
-            false !== strpos($trimmed, ' ')
-            ||
-            false !== stripos($trimmed, 'as')
-            ||
-            false !== stripos($trimmed, 'asc')
-            ||
-            false !== stripos($trimmed, 'desc')
-        ) {
+        if (preg_match('/([ "]|asc?|desc)/', $trimmed)) {
             return $s;
         }
         return $trimmed;

--- a/tests/Dbal/QueryTest.php
+++ b/tests/Dbal/QueryTest.php
@@ -51,6 +51,16 @@ class QueryTest extends PHPUnit_Framework_TestCase
             ['foo AS f', '`bar` b'],
             $reflector->invokeArgs($query, [ ['foo AS f, `bar` b'] ])
         );
+
+        $this->assertEquals(
+            ['public.table'],
+            $reflector->invokeArgs($query, [ ['public.table'] ])
+        );
+
+        $this->assertEquals(
+            ['"public"."tableName"'],
+            $reflector->invokeArgs($query, [ ['"public"."tableName"'] ])
+        );
     }
 
     public function testColumns()


### PR DESCRIPTION
С новым обновлением прилетело:

Если в схеме модели имя таблицы идёт со схемой

`static protected $schema = [
        'table' => 'datamining.job_guarantees',
]`

Который Pgsql::quoteName в [\T4\Dbal\Drivers\Pgsql::find](https://github.com/pr-of-it/t4/blob/master/framework/Dbal/Drivers/Pgsql.php#L396) приводит к виду datamining."job_guarantees"

А затем благополучно обрезается до datamining."job_guarantees методо [\T4\Dbal\Query::prepareNames](https://github.com/pr-of-it/t4/blob/master/framework/Dbal/Query.php#L120)

Тест прилагается