### PR TITLE
Feature/not null

### DIFF
--- a/framework/Dbal/Drivers/Mysql.php
+++ b/framework/Dbal/Drivers/Mysql.php
@@ -137,10 +137,12 @@ class Mysql
                 break;
         }
     
-        if(isset($options['default'])) {
-            $ddl .= ' ' . 'NOT NULL DEFAULT' . ' \'' . $options['default'] .'\'';
-        } elseif (isset($options['null']) && false === $options['null']) {
+        if (isset($options['null']) && false === $options['null']) {
             $ddl .= ' ' . 'NOT NULL';
+        }
+        
+        if(isset($options['default'])) {
+            $ddl .= ' ' . 'DEFAULT' . ' \'' . $options['default'] .'\'';
         }
 
         return $name . ' ' . $ddl;

--- a/framework/Dbal/Drivers/Mysql.php
+++ b/framework/Dbal/Drivers/Mysql.php
@@ -60,9 +60,6 @@ class Mysql
             case 'link':
                 $ddl = 'BIGINT UNSIGNED NULL DEFAULT NULL';
                 break;
-            case 'link-not-null':
-                $ddl = 'BIGINT UNSIGNED NOT NULL';
-                break;
             case 'serial':
                 $ddl = 'SERIAL';
                 break;

--- a/framework/Dbal/Drivers/Mysql.php
+++ b/framework/Dbal/Drivers/Mysql.php
@@ -138,8 +138,8 @@ class Mysql
         }
     
         if(isset($options['default'])) {
-            $ddl .= ' ' . 'DEFAULT' . ' \'' . $options['default'] .'\'';
-        } elseif (true === $options['not-null']) {
+            $ddl .= ' ' . 'NOT NULL DEFAULT' . ' \'' . $options['default'] .'\'';
+        } elseif (isset($options['null']) && false === $options['null']) {
             $ddl .= ' ' . 'NOT NULL';
         }
 

--- a/framework/Dbal/Drivers/Mysql.php
+++ b/framework/Dbal/Drivers/Mysql.php
@@ -60,6 +60,9 @@ class Mysql
             case 'link':
                 $ddl = 'BIGINT UNSIGNED NULL DEFAULT NULL';
                 break;
+            case 'link-not-null':
+                $ddl = 'BIGINT UNSIGNED NOT NULL';
+                break;
             case 'serial':
                 $ddl = 'SERIAL';
                 break;
@@ -136,9 +139,11 @@ class Mysql
                 $ddl = $options['type'];
                 break;
         }
-
+    
         if(isset($options['default'])) {
-            $ddl .= ' ' . 'NOT NULL DEFAULT' . ' \'' . $options['default'] .'\'';
+            $ddl .= ' ' . 'DEFAULT' . ' \'' . $options['default'] .'\'';
+        } elseif (true === $options['not-null']) {
+            $ddl .= ' ' . 'NOT NULL';
         }
 
         return $name . ' ' . $ddl;

--- a/framework/Dbal/Drivers/Mysql.php
+++ b/framework/Dbal/Drivers/Mysql.php
@@ -58,7 +58,7 @@ class Mysql
                 break;
             case 'relation':
             case 'link':
-                $ddl = 'BIGINT UNSIGNED NULL DEFAULT NULL';
+                $ddl = 'BIGINT UNSIGNED';
                 break;
             case 'serial':
                 $ddl = 'SERIAL';

--- a/framework/Dbal/Drivers/Pgsql.php
+++ b/framework/Dbal/Drivers/Pgsql.php
@@ -59,6 +59,9 @@ class Pgsql
             case 'link':
                 $ddl = 'BIGINT';
                 break;
+            case 'link-not-null':
+                $ddl = 'BIGINT NOT NULL';
+                break;
             case 'serial':
                 $ddl = 'SERIAL';
                 break;
@@ -119,6 +122,9 @@ class Pgsql
 
         if (isset($options['default'])) {
             $default = 'ALTER TABLE ' . $this->quoteName($table) . ' ALTER COLUMN ' . $name . ' SET DEFAULT \'' . $options['default'] . '\'';
+            return [$name . ' ' . $ddl, $default];
+        } elseif (true === $options['not-null']) {
+            $default = 'ALTER TABLE ' . $this->quoteName($table) . ' ALTER COLUMN ' . $name . ' SET NOT NULL';
             return [$name . ' ' . $ddl, $default];
         }
 

--- a/framework/Dbal/Drivers/Pgsql.php
+++ b/framework/Dbal/Drivers/Pgsql.php
@@ -120,9 +120,8 @@ class Pgsql
         if (isset($options['default'])) {
             $default = 'ALTER TABLE ' . $this->quoteName($table) . ' ALTER COLUMN ' . $name . ' SET DEFAULT \'' . $options['default'] . '\'';
             return [$name . ' ' . $ddl, $default];
-        } elseif (true === $options['not-null']) {
-            $default = 'ALTER TABLE ' . $this->quoteName($table) . ' ALTER COLUMN ' . $name . ' SET NOT NULL';
-            return [$name . ' ' . $ddl, $default];
+        } elseif (isset($options['null']) && false === $options['null']) {
+            $ddl .= ' ' . 'NOT NULL';
         }
 
         return $name . ' ' . $ddl;

--- a/framework/Dbal/Drivers/Pgsql.php
+++ b/framework/Dbal/Drivers/Pgsql.php
@@ -59,9 +59,6 @@ class Pgsql
             case 'link':
                 $ddl = 'BIGINT';
                 break;
-            case 'link-not-null':
-                $ddl = 'BIGINT NOT NULL';
-                break;
             case 'serial':
                 $ddl = 'SERIAL';
                 break;

--- a/framework/Dbal/Drivers/Pgsql.php
+++ b/framework/Dbal/Drivers/Pgsql.php
@@ -116,12 +116,13 @@ class Pgsql
                 $ddl = $options['type'];
                 break;
         }
-
-        if (isset($options['default'])) {
-            $default = 'ALTER TABLE ' . $this->quoteName($table) . ' ALTER COLUMN ' . $name . ' SET DEFAULT \'' . $options['default'] . '\'';
-            return [$name . ' ' . $ddl, $default];
-        } elseif (isset($options['null']) && false === $options['null']) {
+    
+        if (isset($options['null']) && false === $options['null']) {
             $ddl .= ' ' . 'NOT NULL';
+        }
+    
+        if(isset($options['default'])) {
+            $ddl .= ' ' . 'DEFAULT' . ' \'' . $options['default'] .'\'';
         }
 
         return $name . ' ' . $ddl;

--- a/tests/Dbal/Drivers/MysqlDriverTest.php
+++ b/tests/Dbal/Drivers/MysqlDriverTest.php
@@ -43,6 +43,22 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
             $reflector->invokeArgs($driver, ['foo', ['type' => 'relation']])
         );
         $this->assertEquals(
+            '`foo` BIGINT UNSIGNED NOT NULL',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'relation', 'null' => false]])
+        );
+        $this->assertEquals(
+            '`foo` BIGINT UNSIGNED',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'relation', 'null' => true]])
+        );
+        $this->assertEquals(
+            '`foo` BIGINT UNSIGNED NOT NULL DEFAULT \'1\'',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'relation', 'null' => true, 'default' => 1]])
+        );
+        $this->assertEquals(
+            '`foo` BIGINT UNSIGNED NOT NULL DEFAULT \'1\'',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'relation', 'null' => false, 'default' => 1]])
+        );
+        $this->assertEquals(
             '`foo` SERIAL',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'serial']])
         );
@@ -135,22 +151,6 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals(
             '`foo` LONGTEXT',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'jsonb']])
-        );
-        $this->assertEquals(
-            '`foo` BIGINT UNSIGNED NOT NULL',
-            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => false]])
-        );
-        $this->assertEquals(
-            '`foo` BIGINT UNSIGNED',
-            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => true]])
-        );
-        $this->assertEquals(
-            '`foo` BIGINT UNSIGNED NOT NULL DEFAULT \'1\'',
-            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => true, 'default' => 1]])
-        );
-        $this->assertEquals(
-            '`foo` BIGINT UNSIGNED NOT NULL DEFAULT \'1\'',
-            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => false, 'default' => 1]])
         );
     }
 

--- a/tests/Dbal/Drivers/MysqlDriverTest.php
+++ b/tests/Dbal/Drivers/MysqlDriverTest.php
@@ -51,7 +51,7 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
             $reflector->invokeArgs($driver, ['foo', ['type' => 'relation', 'null' => true]])
         );
         $this->assertEquals(
-            '`foo` BIGINT UNSIGNED NOT NULL DEFAULT \'1\'',
+            '`foo` BIGINT UNSIGNED DEFAULT \'1\'',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'relation', 'null' => true, 'default' => 1]])
         );
         $this->assertEquals(
@@ -67,8 +67,12 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
             $reflector->invokeArgs($driver, ['foo', ['type' => 'boolean']])
         );
         $this->assertEquals(
-            '`foo` INT NOT NULL DEFAULT \'123\'',
+            '`foo` INT DEFAULT \'123\'',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'int', 'default' => '123']])
+        );
+        $this->assertEquals(
+            '`foo` INT NOT NULL DEFAULT \'123\'',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'int', 'default' => '123', 'null' => false]])
         );
         $this->assertEquals(
             '`foo` INT',
@@ -82,9 +86,12 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
             '`foo` FLOAT',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'float']])
         );
-
         $this->assertEquals(
             '`foo` TEXT NOT NULL DEFAULT \'123\'',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'text', 'default' => '123', 'null' => false]])
+        );
+        $this->assertEquals(
+            '`foo` TEXT DEFAULT \'123\'',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'text', 'default' => '123']])
         );
         $this->assertEquals(

--- a/tests/Dbal/Drivers/MysqlDriverTest.php
+++ b/tests/Dbal/Drivers/MysqlDriverTest.php
@@ -39,7 +39,7 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
             $reflector->invokeArgs($driver, ['foo', ['type' => 'pk']])
         );
         $this->assertEquals(
-            '`foo` BIGINT UNSIGNED NULL DEFAULT NULL',
+            '`foo` BIGINT UNSIGNED',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'relation']])
         );
         $this->assertEquals(
@@ -93,6 +93,14 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
             $reflector->invokeArgs($driver, ['foo', ['type' => 'datetime']])
         );
         $this->assertEquals(
+            '`foo` DATETIME NOT NULL',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'datetime', 'null' => false]])
+        );
+        $this->assertEquals(
+            '`foo` DATETIME',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'datetime', 'null' => true]])
+        );
+        $this->assertEquals(
             '`foo` DATE',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'date']])
         );
@@ -127,6 +135,22 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals(
             '`foo` LONGTEXT',
             $reflector->invokeArgs($driver, ['foo', ['type' => 'jsonb']])
+        );
+        $this->assertEquals(
+            '`foo` BIGINT UNSIGNED NOT NULL',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => false]])
+        );
+        $this->assertEquals(
+            '`foo` BIGINT UNSIGNED',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => true]])
+        );
+        $this->assertEquals(
+            '`foo` BIGINT UNSIGNED NOT NULL DEFAULT \'1\'',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => true, 'default' => 1]])
+        );
+        $this->assertEquals(
+            '`foo` BIGINT UNSIGNED NOT NULL DEFAULT \'1\'',
+            $reflector->invokeArgs($driver, ['foo', ['type' => 'link', 'null' => false, 'default' => 1]])
         );
     }
 

--- a/tests/Dbal/Drivers/PgsqlDriverTest.php
+++ b/tests/Dbal/Drivers/PgsqlDriverTest.php
@@ -55,8 +55,16 @@ class PgsqlDriverTest extends \PHPUnit\Framework\TestCase {
             $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'relation', 'null' => false]])
         );
         $this->assertEquals(
+            '"foo" BIGINT NOT NULL DEFAULT \'123\'',
+            $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'relation', 'null' => false, 'default' => '123']])
+        );
+        $this->assertEquals(
             '"foo" BIGINT',
             $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'relation', 'null' => true]])
+        );
+        $this->assertEquals(
+            '"foo" BIGINT DEFAULT \'123\'',
+            $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'relation', 'null' => true, 'default' => '123']])
         );
         $this->assertEquals(
             '"foo" SERIAL',

--- a/tests/Dbal/Drivers/PgsqlDriverTest.php
+++ b/tests/Dbal/Drivers/PgsqlDriverTest.php
@@ -51,6 +51,14 @@ class PgsqlDriverTest extends \PHPUnit\Framework\TestCase {
             $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'relation']])
         );
         $this->assertEquals(
+            '"foo" BIGINT NOT NULL',
+            $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'relation', 'null' => false]])
+        );
+        $this->assertEquals(
+            '"foo" BIGINT',
+            $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'relation', 'null' => true]])
+        );
+        $this->assertEquals(
             '"foo" SERIAL',
             $reflector->invokeArgs($driver, ['table', 'foo', ['type' => 'serial']])
         );


### PR DESCRIPTION
Для БД mySQL и PostgreSQL произведены следующие изменения:
1. Добавлена опция 'null', позволяющая объявлять поле как NOT NULL, если опция === false
2. Дополнены unit тесты по опции 'null'